### PR TITLE
Allow patching/unpatching of the loot system and the colorization system

### DIFF
--- a/StarLevelSystem/Modifiers/DeathNova.cs
+++ b/StarLevelSystem/Modifiers/DeathNova.cs
@@ -15,6 +15,10 @@ namespace StarLevelSystem.Modifiers
 {
     internal static class DeathNova
     {
+        internal static void Patch(Harmony harmony) {
+          harmony.PatchAll(typeof(DeathNovaOnDeathPatch));
+        }
+
         [HarmonyPatch(typeof(Character), nameof(Character.OnDeath))]
         public static class DeathNovaOnDeathPatch
         {

--- a/StarLevelSystem/Modifiers/Drainers.cs
+++ b/StarLevelSystem/Modifiers/Drainers.cs
@@ -8,6 +8,10 @@ namespace StarLevelSystem.Modifiers
 {
     internal static class Drainers
     {
+        internal static void Patch(Harmony harmony) {
+          harmony.PatchAll(typeof(ModifierDrain));
+        }
+
         [HarmonyPatch(typeof(Character), nameof(Character.Damage))]
         public static class ModifierDrain
         {

--- a/StarLevelSystem/Modifiers/LifeLink.cs
+++ b/StarLevelSystem/Modifiers/LifeLink.cs
@@ -10,6 +10,10 @@ namespace StarLevelSystem.Modifiers
 {
     public static class LifeLink
     {
+        internal static void Patch(Harmony harmony) {
+          harmony.PatchAll(typeof(LifeLinkDamageDistributionPatch));
+        }
+
         [HarmonyPatch(typeof(Character), nameof(Character.RPC_Damage))]
         public static class LifeLinkDamageDistributionPatch {
             public static void Prefix(Character __instance, HitData hit) {

--- a/StarLevelSystem/Modifiers/Lootbags.cs
+++ b/StarLevelSystem/Modifiers/Lootbags.cs
@@ -12,6 +12,10 @@ namespace StarLevelSystem.Modifiers
 {
     internal static class Lootbags
     {
+        internal static void Patch(Harmony harmony) {
+          harmony.PatchAll(typeof(CreatureLootMultiplied));
+        }
+
         [UsedImplicitly]
         public static void Setup(Character creature, CreatureModConfig config, CreatureDetailCache ccache) {
             if (ccache == null) { return; }

--- a/StarLevelSystem/Modifiers/SoulEater.cs
+++ b/StarLevelSystem/Modifiers/SoulEater.cs
@@ -13,6 +13,9 @@ namespace StarLevelSystem.Modifiers
 {
     internal static class SoulEater
     {
+        internal static void Patch(Harmony harmony) {
+          harmony.PatchAll(typeof(SoulEaterOnDeath));
+        }
 
         [HarmonyPatch(typeof(Character), nameof(Character.OnDeath))]
         public static class SoulEaterOnDeath

--- a/StarLevelSystem/Modifiers/Splitter.cs
+++ b/StarLevelSystem/Modifiers/Splitter.cs
@@ -8,6 +8,10 @@ using static StarLevelSystem.Data.CreatureModifiersData;
 namespace StarLevelSystem.Modifiers
 {
     public static class Splitter {
+        internal static void Patch(Harmony harmony) {
+          harmony.PatchAll(typeof(CharacterOnDeath));
+        }
+
         [HarmonyPatch(typeof(Character), nameof(Character.OnDeath))]
         public static class CharacterOnDeath {
             public static void Prefix(Character __instance) {

--- a/StarLevelSystem/StarLevelSystem.cs
+++ b/StarLevelSystem/StarLevelSystem.cs
@@ -6,6 +6,7 @@ using Jotunn.Managers;
 using Jotunn.Utils;
 using StarLevelSystem.common;
 using StarLevelSystem.Data;
+using StarLevelSystem.Modifiers;
 using StarLevelSystem.modules;
 using System.Reflection;
 using UnityEngine;
@@ -27,7 +28,6 @@ namespace StarLevelSystem
         // https://valheim-modding.github.io/Jotunn/tutorials/localization.html
         public static CustomLocalization Localization = LocalizationManager.Instance.GetLocalization();
         public static AssetBundle EmbeddedResourceBundle;
-        public static Harmony HarmonyInstance { get; private set; }
         public static ManualLogSource Log;
 
         public void Awake()
@@ -37,12 +37,11 @@ namespace StarLevelSystem
             cfg.SetupConfigRPCs();
             cfg.LoadYamlConfigs();
 
-            EmbeddedResourceBundle = AssetUtils.LoadAssetBundleFromResources("StarLevelSystem.assets.starlevelsystems", typeof(StarLevelSystem).Assembly);
-            HarmonyInstance = Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly(), harmonyInstanceId: PluginGUID);
+            EmbeddedResourceBundle = AssetUtils.LoadAssetBundleFromResources("StarLevelSystem.assets.starlevelsystems", typeof(StarLevelSystem).Assembly);       
             Colorization.Init();
-            LevelSystemData.Init();
-            LootSystemData.Init();
-            CreatureModifiersData.Init();
+            LootLevelsExpanded.Init();
+            LevelSystem.Init();
+            ModificationExtensionSystem.Init();
             LocalizationLoader.AddLocalizations();
             PrefabManager.OnVanillaPrefabsAvailable += CreatureModifiersData.LoadPrefabs;
             PrefabManager.OnVanillaPrefabsAvailable += LevelSystem.UpdateMaxLevel;

--- a/StarLevelSystem/common/Config.cs
+++ b/StarLevelSystem/common/Config.cs
@@ -31,6 +31,7 @@ namespace StarLevelSystem
         public static ConfigEntry<int> MiniMapRingGeneratorUpdatesPerFrame;
         public static ConfigEntry<string> DistanceRingColorOptions;
         public static ConfigEntry<bool> ControlSpawnerLevels;
+        public static ConfigEntry<bool> EnableModificationSystem;
         public static ConfigEntry<bool> ForceControlAllSpawns;
         public static ConfigEntry<string> SpawnsAlwaysControlled;
         public static ConfigEntry<bool> ControlBossSpawns;
@@ -38,6 +39,7 @@ namespace StarLevelSystem
         public static ConfigEntry<bool> EnableCreatureScalingPerLevel;
         public static ConfigEntry<bool> EnableScalingInDungeons;
         public static ConfigEntry<float> PerLevelScaleBonus;
+        public static ConfigEntry<bool> EnableLootSystem;
         public static ConfigEntry<float> PerLevelLootScale;
         public static ConfigEntry<int> LootDropsPerTick;
         public static ConfigEntry<string> LootDropCalculationType;
@@ -145,9 +147,11 @@ namespace StarLevelSystem
             ForceControlAllSpawns = BindServerConfig("LevelSystem", "ForceControlAllSpawns", false, "Forces all creatures to be controlled by SLS, this includes creatures spawned from player abilities and items. This will override creature levels, other mods must use the API to ensure their spawned creature levels are set.");
             //DistanceBonusMapsCanIncludeLowerLevels = BindServerConfig("LevelSystem", "DistanceBonusMapsCanIncludeLowerLevels", true, "When enabled makes the distance bonus configuration include the highest previously lower level defined keys, if they are not defined in the current level.");
             SpawnsAlwaysControlled = BindServerConfig("LevelSystem", "SpawnsAlwaysControlled", "piece_TrainingDummy", "A list of creatures which always get their level set");
+            EnableModificationSystem = BindServerConfig("LevelSystem", "EnableModificationSystem", true, "Toggles the modification system on or off"); 
             SpawnsAlwaysControlled.SettingChanged += ModificationExtensionSystem.LeveledCreatureListChanged;
             ModificationExtensionSystem.SetupForceLeveledCreatureList();
 
+            EnableLootSystem = BindServerConfig("LootSystem", "EnableLootSystem", true, "Toggles the loot system off or on");
             PerLevelLootScale = BindServerConfig("LootSystem", "PerLevelLootScale", 1f, "The amount of additional loot that a creature provides per each star level", false, 0f, 4f);
             LootDropCalculationType = BindServerConfig("LootSystem", "LootDropCaluationType", "PerLevel", "The type of loot calculation to use. Per Level ", LootLevelsExpanded.AllowedLootFactors, false);
             LootDropCalculationType.SettingChanged += LootLevelsExpanded.LootFactorChanged;

--- a/StarLevelSystem/common/TerminalCommands.cs
+++ b/StarLevelSystem/common/TerminalCommands.cs
@@ -20,6 +20,8 @@ namespace StarLevelSystem.common
             CommandManager.Instance.AddConsoleCommand(new ResetZOIDModifiers());
             CommandManager.Instance.AddConsoleCommand(new GiveCreatureModifier());
             CommandManager.Instance.AddConsoleCommand(new DumpLootTablesCommand());
+            CommandManager.Instance.AddConsoleCommand(new EnableLootSystemCommand());
+            CommandManager.Instance.AddConsoleCommand(new EnableColorizationCommand());
         }
 
         internal class GiveCreatureModifier : ConsoleCommand
@@ -136,6 +138,48 @@ namespace StarLevelSystem.common
                 {
                     writetext.WriteLine(yaml);
                 }
+            }
+        }
+
+        internal class EnableColorizationCommand : ConsoleCommand
+        {
+            public override string Name => "SLS-Enable-Colorization";
+
+            public override string Help => "Enables or disables the Colorization";
+
+            public override bool IsCheat => true;
+
+            public override void Run(string[] args) {
+                if (args.Length < 1) {
+                    Console.instance?.Print($"Colorization = {ValConfig.EnableLootSystem.Value}");
+                    return;
+                }
+                if (!bool.TryParse(args[0], out bool result)) {
+                    Console.instance?.Print("Invalid argument; must be true or false");
+                    return;
+                }
+                ValConfig.EnableColorization.Value = result;
+            }
+        }
+
+        internal class EnableLootSystemCommand : ConsoleCommand
+        {
+            public override string Name => "SLS-Enable-LootSystem";
+
+            public override string Help => "Enables or disables the LootSystem";
+
+            public override bool IsCheat => true;
+
+            public override void Run(string[] args) {
+                if (args.Length < 1) {
+                    Console.instance?.Print($"LootSystem = {ValConfig.EnableLootSystem.Value}");
+                    return;
+                }
+                if (!bool.TryParse(args[0], out bool result)) {
+                    Console.instance?.Print("Invalid argument; must be true or false");
+                    return;
+                }
+                ValConfig.EnableLootSystem.Value = result;
             }
         }
     }

--- a/StarLevelSystem/modules/Colorization.cs
+++ b/StarLevelSystem/modules/Colorization.cs
@@ -54,6 +54,19 @@ namespace StarLevelSystem.modules
             try {
                 UpdateYamlConfig(File.ReadAllText(ValConfig.colorsFilePath));
             } catch (Exception e) { Jotunn.Logger.LogWarning($"There was an error updating the Color Level values, defaults will be used. Exception: {e}"); }
+            
+            var harmony = new Harmony($"{StarLevelSystem.PluginGUID}.Colorization");
+            if (ValConfig.EnableColorization.Value) {
+              Patch(harmony);
+            }
+            ValConfig.EnableColorization.SettingChanged += (s, e) => {
+              if (ValConfig.EnableColorization.Value) Patch(harmony);
+              else harmony.UnpatchSelf();
+            };
+        }
+
+        private static void Patch(Harmony harmony) {
+          harmony.PatchAll(typeof(PreventDefaultLevelSetup));
         }
 
         public static string YamlDefaultConfig() {

--- a/StarLevelSystem/modules/LevelSystem.cs
+++ b/StarLevelSystem/modules/LevelSystem.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using Jotunn.Extensions;
 using Jotunn.Managers;
 using StarLevelSystem.common;
 using StarLevelSystem.Data;
@@ -17,6 +16,34 @@ namespace StarLevelSystem.modules
     {
         public static Vector3 center = new Vector3(0, 0, 0);
         private static bool buildingMapRings = false;
+ 
+        internal static void Init() {
+          LevelSystemData.Init();
+          var harmony = new Harmony($"{StarLevelSystem.PluginGUID}.levelSystem");
+          Patch(harmony);
+        }
+
+        private static void Patch(Harmony harmony) {
+            harmony.PatchAll(typeof(CreatureSpawnerSpawn));
+            harmony.PatchAll(typeof(DropOnDestroyedSpawnPatch));
+            harmony.PatchAll(typeof(EggHatchSpawnPatch));
+            harmony.PatchAll(typeof(RandomFishLevelExtension));
+            harmony.PatchAll(typeof(RandomFlyingBirdExtension));
+            harmony.PatchAll(typeof(RandomTreeLevelExtension));
+            harmony.PatchAll(typeof(SetChildLevel));
+            harmony.PatchAll(typeof(SetGrowUpLevel));
+            harmony.PatchAll(typeof(SetTreeLogPassLevel));
+            harmony.PatchAll(typeof(SetupMaxLevelDamagePatch));
+            harmony.PatchAll(typeof(SpawnAbilitySpawnPatch));
+            harmony.PatchAll(typeof(SpawnAreaSpawnOnePatch));
+            harmony.PatchAll(typeof(SpawnSystemSpawnPatch));
+            harmony.PatchAll(typeof(TriggerSpawnerSpawnPatch));
+
+            LevelUI.Patch(harmony);
+            MultiplayerDamageMod.Patch(harmony);
+            MultiplayerHealthMod.Patch(harmony);
+            SpawnLevelExtension.Patch(harmony);
+        }
 
         public static void SetAndUpdateCharacterLevel(Character character, int level) {
             if (character == null) { return; }

--- a/StarLevelSystem/modules/LevelUI.cs
+++ b/StarLevelSystem/modules/LevelUI.cs
@@ -27,6 +27,14 @@ namespace StarLevelSystem.modules
         public static Dictionary<ZDOID, StarLevelHud> characterExtendedHuds = new Dictionary<ZDOID, StarLevelHud>();
         private static GameObject star;
 
+        internal static void Patch(Harmony harmony) {
+            harmony.PatchAll(typeof(DestroyEnemyHud));
+            harmony.PatchAll(typeof(DisableVanillaStarsByDefault));
+            harmony.PatchAll(typeof(DisplayCreatureNameChanges));
+            harmony.PatchAll(typeof(EnableLevelDisplay));
+            harmony.PatchAll(typeof(SetupCreatureLevelDisplay));
+        }
+
         public static void InvalidateCacheEntry(ZDOID zdo)
         {
             if (characterExtendedHuds.ContainsKey(zdo)) { characterExtendedHuds.Remove(zdo); }

--- a/StarLevelSystem/modules/LootLevelsExpanded.cs
+++ b/StarLevelSystem/modules/LootLevelsExpanded.cs
@@ -12,6 +12,27 @@ namespace StarLevelSystem.modules
 {
     public static class LootLevelsExpanded
     {
+        internal static void Init() {
+            LootSystemData.Init();
+
+            var harmony = new Harmony($"{StarLevelSystem.PluginGUID}.LootSystem");
+            if (ValConfig.EnableLootSystem.Value) {
+              Patch(harmony);
+            }
+            ValConfig.EnableLootSystem.SettingChanged += (s, e) => {
+              if (ValConfig.EnableLootSystem.Value) Patch(harmony);
+              else harmony.UnpatchSelf();
+            };
+        }
+
+        private static void Patch(Harmony harmony) {
+            harmony.PatchAll(typeof(CalculateLootPerLevelStyle));
+            harmony.PatchAll(typeof(DropItemsPerformancePatch));
+            harmony.PatchAll(typeof(DropItemsPerformancePatch));
+            harmony.PatchAll(typeof(ModifyLootPerLevelEffect));
+            harmony.PatchAll(typeof(RemoveDropLimit));
+        }
+
         public enum LootFactorType
         {
             PerLevel,

--- a/StarLevelSystem/modules/ModificationExtensionSystem.cs
+++ b/StarLevelSystem/modules/ModificationExtensionSystem.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using StarLevelSystem.Data;
+using StarLevelSystem.Modifiers;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -14,6 +15,38 @@ namespace StarLevelSystem.modules
     {
 
         static List<string> ForceLeveledCreatures = new List<string>();
+
+        internal static void Init() {
+            CreatureModifiersData.Init();
+
+            var harmony = new Harmony($"{StarLevelSystem.PluginGUID}.ModificationSystem");
+            if (ValConfig.EnableModificationSystem.Value) {
+              Patch(harmony);
+            }
+            ValConfig.EnableModificationSystem.SettingChanged += (s, e) => {
+              if (ValConfig.EnableModificationSystem.Value) Patch(harmony);
+              else harmony.UnpatchSelf();
+            };
+        }
+
+        private static void Patch(Harmony harmony) {
+            // Configure modifiers that require patching.
+            DeathNova.Patch(harmony);
+            Drainers.Patch(harmony);
+            LifeLink.Patch(harmony);
+            Lootbags.Patch(harmony);
+            SoulEater.Patch(harmony);
+            Splitter.Patch(harmony);
+            // Setup hooks for overall modification module.
+            harmony.PatchAll(typeof(CharacterDamageModificationApply));
+            harmony.PatchAll(typeof(CreatureCharacterExtension));
+            harmony.PatchAll(typeof(CreatureSizeSyncEquipItems));
+            harmony.PatchAll(typeof(ModifyCharacterAnimationSpeed));
+            harmony.PatchAll(typeof(ModifyCharacterVisualsToLevel));
+            harmony.PatchAll(typeof(ModifyRagdollHumanoid));
+            harmony.PatchAll(typeof(PostfixSetupBosses));
+            harmony.PatchAll(typeof(VisualEquipmentScaleToFit));
+        }
 
         internal static void LeveledCreatureListChanged(object s, EventArgs e)
         {

--- a/StarLevelSystem/modules/MultiplayerDamageMod.cs
+++ b/StarLevelSystem/modules/MultiplayerDamageMod.cs
@@ -4,6 +4,10 @@ using UnityEngine;
 namespace StarLevelSystem.modules
 {
     public static class MultiplayerDamageMod {
+        internal static void Patch(Harmony harmony) {
+            harmony.PatchAll(typeof(PatchPerPlayerDamageScaling));
+        }
+        
         [HarmonyPatch(typeof(Game), nameof(Game.GetDifficultyDamageScalePlayer))]
         public static class PatchPerPlayerDamageScaling {
             public static bool Prefix(Game __instance, Vector3 pos, ref float __result) {
@@ -25,6 +29,10 @@ namespace StarLevelSystem.modules
     }
 
     public static class MultiplayerHealthMod {
+        internal static void Patch(Harmony harmony) {
+            harmony.PatchAll(typeof(PatchPerPlayerDamageScaling));
+        }
+
         [HarmonyPatch(typeof(Game), nameof(Game.GetDifficultyDamageScaleEnemy))]
         public static class PatchPerPlayerDamageScaling {
             public static bool Prefix(Game __instance, Vector3 pos, ref float __result) {

--- a/StarLevelSystem/modules/SpawnLevelExtension.cs
+++ b/StarLevelSystem/modules/SpawnLevelExtension.cs
@@ -11,6 +11,10 @@ namespace StarLevelSystem.modules
 {
     class SpawnLevelExtension
     {
+        internal static void Patch(Harmony harmony) {
+            harmony.PatchAll(typeof(SpawnCommandDelegate));
+        }
+
         [HarmonyPatch]
         static class SpawnCommandDelegate
         {


### PR DESCRIPTION
 - Moves to patch classes directly. I don't think Harmony will do this recursively for inner classes, so I think each class has to be patched. This allows for unpatching when the configuration option changes
 - Moved into 4 top level harmony objects. I think this makes sense from an organization perspective?
 - Added console commands for enabling/disabling loot and colorization. I tested these locally and they seem to disable/enable properly. Colorization stays after disabling for enemies spawned since that appears to be a mutate, rather than a behavior change
 - Moved the data Init()'s inline 