### PR TITLE
Fix dedicated server custom raid event starts

### DIFF
--- a/StarLevelSystem/common/Config.cs
+++ b/StarLevelSystem/common/Config.cs
@@ -557,8 +557,12 @@ namespace StarLevelSystem
         private static IEnumerator OnClientRecieveRaidStart(long sender, ZPackage package) {
             var yaml = package.ReadString();
             RaidDefinition raiddef = DataObjects.yamldeserializer.Deserialize<RaidDefinition>(yaml);
+            Vector3 raidPosition = Player.m_localPlayer != null ? Player.m_localPlayer.transform.position : Vector3.zero;
+            if (RaidControl.TryReadRaidPosition(package, out Vector3 networkedPosition)) {
+                raidPosition = networkedPosition;
+            }
 
-            RaidControl.StartRaidRunner(raiddef, Player.m_localPlayer.transform.position);
+            RaidControl.StartRaidRunner(raiddef, raidPosition);
 
             // Add in a check if we want to write the server config to disk or use it virtually
             yield return null;

--- a/StarLevelSystem/modules/Raids/RaidControl.cs
+++ b/StarLevelSystem/modules/Raids/RaidControl.cs
@@ -34,6 +34,46 @@ namespace StarLevelSystem.modules.Raids
             raidRun.StartRaid(targetRaid, Player.m_localPlayer);
         }
 
+        internal static bool StartNetworkedRaidRunner(RaidDefinition targetRaid, Vector3 pos) {
+            ZNetPeer peer = GetNearestReadyPeer(pos);
+            if (peer == null) {
+                Logger.LogWarning($"Unable to start raid {targetRaid.Name}; no ready peers were available for the client-side raid runner.");
+                return false;
+            }
+
+            Vector3 raidPosition = pos;
+            if (raidPosition.y == 0f) {
+                raidPosition.y = peer.m_refPos.y;
+            }
+
+            Logger.LogDebug($"Sending networked raid runner for {targetRaid.Name} to {peer.m_playerName} at {raidPosition}");
+            ValConfig.ClientStartRaidRPC.SendPackage(peer.m_uid, CreateStartRaidPackage(targetRaid, raidPosition));
+            ForceMusicForClientsInArea(targetRaid.ForceMusic, raidPosition, targetRaid.EventRange * 1.5f);
+            return true;
+        }
+
+        internal static ZPackage CreateStartRaidPackage(RaidDefinition targetRaid, Vector3 pos) {
+            ZPackage zpack = new ZPackage();
+            zpack.Write(DataObjects.yamlserializer.Serialize(targetRaid));
+            zpack.Write(pos);
+            return zpack;
+        }
+
+        internal static bool TryReadRaidPosition(ZPackage package, out Vector3 pos) {
+            pos = Vector3.zero;
+            if (package.GetPos() >= package.Size()) { return false; }
+            pos = package.ReadVector3();
+            return true;
+        }
+
+        private static ZNetPeer GetNearestReadyPeer(Vector3 pos) {
+            if (ZNet.instance == null) { return null; }
+            return ZNet.instance.GetPeers()
+                .Where(peer => peer != null && peer.IsReady() && peer.m_characterID != ZDOID.None)
+                .OrderBy(peer => Utils.DistanceXZ(peer.m_refPos, pos))
+                .FirstOrDefault();
+        }
+
         public static RaidDefinition RandomSelectValidRaidForPlayer(string playerPlatformID) {
             if (RaidsData.SLE_Raid_Settings.Raids.Count == 0) {
                 Logger.LogWarning("No Raids were defined.");

--- a/StarLevelSystem/modules/Raids/RaidManager.cs
+++ b/StarLevelSystem/modules/Raids/RaidManager.cs
@@ -152,8 +152,7 @@ namespace StarLevelSystem.modules.Raids {
                                 MusicMan.instance.TriggerMusic(raid.ForceMusic.ToString());
                             } else {
                                 Logger.LogDebug("Starting networked raid runner.");
-                                ZPackage zpack = new ZPackage();
-                                zpack.Write(DataObjects.yamlserializer.Serialize(raid));
+                                ZPackage zpack = RaidControl.CreateStartRaidPackage(raid, raidPosition);
                                 ZNetPeer zpeer = SLSExtensions.GetPeerByPlatformID(playerRaids.Key);
                                 ValConfig.ClientStartRaidRPC.SendPackage(zpeer.m_uid, zpack);
                             }

--- a/StarLevelSystem/modules/Raids/RaidPatches.cs
+++ b/StarLevelSystem/modules/Raids/RaidPatches.cs
@@ -53,10 +53,17 @@ namespace StarLevelSystem.modules.Raids
         public static class SetRandomCustomEvent {
             public static bool Prefix(RandEventSystem __instance, RandomEvent ev, Vector3 pos) {
                 if (ValConfig.UseVanillaRaidConfiguration.Value) { return true; }
+                if (ev == null) { return true; }
+
                 Logger.LogDebug($"Checking for random Raid {ev.m_name}");
                 RaidsData.RaidsByName.TryGetValue(ev.m_name, out RaidDefinition raidDef);
                 if (raidDef == null) {
                     Logger.LogWarning($"SetRandomEvent called for '{ev.m_name}' but no matching SLS raid definition found — event dropped. Add it to RaidSettings.yaml or enable UseVanillaRaidConfiguration.");
+                    return false;
+                }
+
+                if (ZNet.instance != null && ZNet.instance.IsDedicated()) {
+                    StartNetworkedRaidRunner(raidDef, pos);
                     return false;
                 }
 


### PR DESCRIPTION
Fixes SLS custom raid events triggered from a dedicated server with an explicit world position.

Previously, when the server ran an event command like `event raid_name x z`, SLS found the matching raid definition but tried to start the raid runner locally on the dedicated server. Dedicated servers do not have a local player/client raid runner, so the command appeared to succeed but the SLS raid did not actually start for players.

This changes the dedicated-server path to send the raid start to the nearest ready client and includes the requested event position in the RPC package. Clients still run the existing raid runner logic, but now at the intended server-provided location.